### PR TITLE
Updating to MSAL.NET 4.16

### DIFF
--- a/WebApp/App_Start/Startup.Auth.cs
+++ b/WebApp/App_Start/Startup.Auth.cs
@@ -66,7 +66,7 @@ namespace WebApp
         private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedNotification context)
         {
             // Upon successful sign in, get the access token & cache it using MSAL
-            IConfidentialClientApplication clientApp = MsalAppBuilder.BuildConfidentialClientApplication(new ClaimsPrincipal(context.AuthenticationTicket.Identity));
+            IConfidentialClientApplication clientApp = MsalAppBuilder.BuildConfidentialClientApplication();
             AuthenticationResult result = await clientApp.AcquireTokenByAuthorizationCode(new[] { "Mail.Read" }, context.Code).ExecuteAsync();
         }
 

--- a/WebApp/Controllers/HomeController.cs
+++ b/WebApp/Controllers/HomeController.cs
@@ -48,13 +48,13 @@ namespace WebApp.Controllers
             // Before we render the send email screen, we use the incremental consent to obtain and cache the access token with the correct scopes
             IConfidentialClientApplication app = MsalAppBuilder.BuildConfidentialClientApplication();
             AuthenticationResult result = null;
-            var accounts = await app.GetAccountsAsync();
+            var account = await app.GetAccountAsync(ClaimsPrincipal.Current.GetMsalAccountId());
             string[] scopes = { "Mail.Send" };
 
             try
             {
 				// try to get an already cached token
-				result = await app.AcquireTokenSilent(scopes, accounts.FirstOrDefault()).ExecuteAsync().ConfigureAwait(false);
+				result = await app.AcquireTokenSilent(scopes, account).ExecuteAsync().ConfigureAwait(false);
             }
             catch (MsalUiRequiredException ex)
             {
@@ -108,7 +108,7 @@ namespace WebApp.Controllers
             string message = String.Format(messagetemplate, subject, body, recipient);
 
             HttpClient client = new HttpClient();
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/microsoft.graph.sendMail")
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/sendMail")
             {
                 Content = new StringContent(message, Encoding.UTF8, "application/json")
             };
@@ -116,13 +116,13 @@ namespace WebApp.Controllers
 
             IConfidentialClientApplication app = MsalAppBuilder.BuildConfidentialClientApplication();
             AuthenticationResult result = null;
-            var accounts = await app.GetAccountsAsync();
+            var account = await app.GetAccountAsync(ClaimsPrincipal.Current.GetMsalAccountId());
             string[] scopes = { "Mail.Send" };
 
             try
             {
 				// try to get an already cached token
-				result = await app.AcquireTokenSilent(scopes, accounts.FirstOrDefault()).ExecuteAsync().ConfigureAwait(false);
+				result = await app.AcquireTokenSilent(scopes, account).ExecuteAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -158,13 +158,13 @@ namespace WebApp.Controllers
         {
             IConfidentialClientApplication app = MsalAppBuilder.BuildConfidentialClientApplication();
             AuthenticationResult result = null;
-            var accounts = await app.GetAccountsAsync();
+            var account = await app.GetAccountAsync(ClaimsPrincipal.Current.GetMsalAccountId());
             string[] scopes = { "Mail.Read" };
 
             try
             {
                 // try to get token silently
-                result = await app.AcquireTokenSilent(scopes, accounts.FirstOrDefault()).ExecuteAsync().ConfigureAwait(false);
+                result = await app.AcquireTokenSilent(scopes, account).ExecuteAsync().ConfigureAwait(false);
             }
             catch (MsalUiRequiredException)
             {

--- a/WebApp/MailApp.csproj
+++ b/WebApp/MailApp.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Identity.Client, Version=4.7.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.4.7.1\lib\net45\Microsoft.Identity.Client.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client, Version=4.16.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.4.16.0\lib\net45\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.5.4.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>

--- a/WebApp/Utils/MSALPerUserMemoryTokenCache.cs
+++ b/WebApp/Utils/MSALPerUserMemoryTokenCache.cs
@@ -47,66 +47,30 @@ namespace WebApp.Utils
         private readonly DateTimeOffset cacheDuration = DateTimeOffset.Now.AddHours(48);
 
         /// <summary>
-        /// Once the user signes in, this will not be null and can be obtained via a call to Thread.CurrentPrincipal
-        /// </summary>
-        internal ClaimsPrincipal SignedInUser;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="MSALPerUserMemoryTokenCache"/> class.
         /// </summary>
         /// <param name="tokenCache">The client's instance of the token cache.</param>
         public MSALPerUserMemoryTokenCache(ITokenCache tokenCache)
         {
-            Initialize(tokenCache, ClaimsPrincipal.Current);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MSALPerUserMemoryTokenCache"/> class.
-        /// </summary>
-        /// <param name="tokenCache">The client's instance of the token cache.</param>
-        /// <param name="user">The signed-in user for whom the cache needs to be established.</param>
-        public MSALPerUserMemoryTokenCache(ITokenCache tokenCache, ClaimsPrincipal user)
-        {
-            Initialize(tokenCache, user);
+            Initialize(tokenCache);
         }
 
         /// <summary>Initializes the cache instance</summary>
         /// <param name="tokenCache">The ITokenCache passed through the constructor</param>
         /// <param name="user">The signed-in user for whom the cache needs to be established..</param>
-        private void Initialize(ITokenCache tokenCache, ClaimsPrincipal user)
+        private void Initialize(ITokenCache tokenCache)
         {
-            SignedInUser = user;
-
             tokenCache.SetBeforeAccess(UserTokenCacheBeforeAccessNotification);
             tokenCache.SetAfterAccess(UserTokenCacheAfterAccessNotification);
             tokenCache.SetBeforeWrite(UserTokenCacheBeforeWriteNotification);
-
-            if (SignedInUser == null)
-            {
-                // No users signed in yet, so we return
-                return;
-            }
-        }
-
-        /// <summary>
-        /// Explores the Claims of a signed-in user (if available) to populate the unique Id of this cache's instance.
-        /// </summary>
-        /// <returns>The signed in user's object.tenant Id , if available in the ClaimsPrincipal.Current instance</returns>
-        internal string GetMsalAccountId()
-        {
-            if (SignedInUser != null)
-            {
-                return SignedInUser.GetMsalAccountId();
-            }
-            return null;
         }
 
         /// <summary>
         /// Clears the TokenCache's copy of this user's cache.
         /// </summary>
-        public void Clear()
+        public void Clear(string key)
         {
-            memoryCache.Remove(GetMsalAccountId());
+            memoryCache.Remove(key);
         }
 
         /// <summary>
@@ -115,18 +79,24 @@ namespace WebApp.Utils
         /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
         private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
         {
-            SetSignedInUserFromNotificationArgs(args);
-
             // if the access operation resulted in a cache update
             if (args.HasStateChanged)
             {
-                string cacheKey = GetMsalAccountId();
+                string cacheKey = args.SuggestedCacheKey ?? args.Account?.HomeAccountId?.Identifier;
 
-                if (string.IsNullOrWhiteSpace(cacheKey))
-                    return;
+                if (args.HasTokens)
+                {
 
-                // Ideally, methods that load and persist should be thread safe.MemoryCache.Get() is thread safe.
-                this.memoryCache.Set(cacheKey, args.TokenCache.SerializeMsalV3(), cacheDuration);
+                    if (string.IsNullOrWhiteSpace(cacheKey))
+                        return;
+
+                    // Ideally, methods that load and persist should be thread safe.MemoryCache.Get() is thread safe.
+                    this.memoryCache.Set(cacheKey, args.TokenCache.SerializeMsalV3(), cacheDuration);
+                }
+                else
+                {
+                    this.memoryCache.Remove(cacheKey);
+                }
             }
         }
 
@@ -136,10 +106,11 @@ namespace WebApp.Utils
         /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
         private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
         {
-            string cacheKey = GetMsalAccountId();
-
-            if (string.IsNullOrWhiteSpace(cacheKey))
+            string cacheKey = args.SuggestedCacheKey ?? args.Account?.HomeAccountId?.Identifier;
+            if (string.IsNullOrEmpty(cacheKey))
+            {
                 return;
+            }
 
             byte[] tokenCacheBytes = (byte[])this.memoryCache.Get(cacheKey);
             args.TokenCache.DeserializeMsalV3(tokenCacheBytes, shouldClearExistingCache: true);
@@ -152,19 +123,6 @@ namespace WebApp.Utils
         private void UserTokenCacheBeforeWriteNotification(TokenCacheNotificationArgs args)
         {
             // Since we are using a MemoryCache ,whose methods are threads safe, we need not to do anything in this handler.
-        }
-
-        /// <summary>
-        /// To keep the cache, ClaimsPrincipal and Sql in sync, we ensure that the user's object Id we obtained by MSAL after
-        /// successful sign-in is set as the key for the cache.
-        /// </summary>
-        /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
-        private void SetSignedInUserFromNotificationArgs(TokenCacheNotificationArgs args)
-        {
-            if (SignedInUser == null && args.Account != null)
-            {
-                SignedInUser = args.Account.ToClaimsPrincipal();
-            }
         }
     }
 }

--- a/WebApp/Utils/MSALPerUserMemoryTokenCache.cs
+++ b/WebApp/Utils/MSALPerUserMemoryTokenCache.cs
@@ -66,14 +66,6 @@ namespace WebApp.Utils
         }
 
         /// <summary>
-        /// Clears the TokenCache's copy of this user's cache.
-        /// </summary>
-        public void Clear(string key)
-        {
-            memoryCache.Remove(key);
-        }
-
-        /// <summary>
         /// Triggered right after MSAL accessed the cache.
         /// </summary>
         /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
@@ -82,20 +74,18 @@ namespace WebApp.Utils
             // if the access operation resulted in a cache update
             if (args.HasStateChanged)
             {
-                string cacheKey = args.SuggestedCacheKey ?? args.Account?.HomeAccountId?.Identifier;
-
+                string cacheKey = args.SuggestedCacheKey;
                 if (args.HasTokens)
                 {
-
                     if (string.IsNullOrWhiteSpace(cacheKey))
                         return;
 
                     // Ideally, methods that load and persist should be thread safe.MemoryCache.Get() is thread safe.
-                    this.memoryCache.Set(cacheKey, args.TokenCache.SerializeMsalV3(), cacheDuration);
+                    memoryCache.Set(cacheKey, args.TokenCache.SerializeMsalV3(), cacheDuration);
                 }
                 else
                 {
-                    this.memoryCache.Remove(cacheKey);
+                    memoryCache.Remove(cacheKey);
                 }
             }
         }
@@ -106,13 +96,13 @@ namespace WebApp.Utils
         /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
         private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
         {
-            string cacheKey = args.SuggestedCacheKey ?? args.Account?.HomeAccountId?.Identifier;
+            string cacheKey = args.SuggestedCacheKey;
             if (string.IsNullOrEmpty(cacheKey))
             {
                 return;
             }
 
-            byte[] tokenCacheBytes = (byte[])this.memoryCache.Get(cacheKey);
+            byte[] tokenCacheBytes = (byte[])memoryCache.Get(cacheKey);
             args.TokenCache.DeserializeMsalV3(tokenCacheBytes, shouldClearExistingCache: true);
         }
 

--- a/WebApp/Utils/MsalAppBuilder.cs
+++ b/WebApp/Utils/MsalAppBuilder.cs
@@ -55,8 +55,10 @@ namespace WebApp.Utils
             // We only clear the user's tokens.
             MSALPerUserMemoryTokenCache userTokenCache = new MSALPerUserMemoryTokenCache(clientapp.UserTokenCache);
             var userAccount = await clientapp.GetAccountAsync(ClaimsPrincipal.Current.GetMsalAccountId());
-
-            await clientapp.RemoveAsync(userAccount);
+            if (userAccount != null)
+            {
+                await clientapp.RemoveAsync(userAccount);
+            }
         }
     }
 }

--- a/WebApp/Utils/MsalAppBuilder.cs
+++ b/WebApp/Utils/MsalAppBuilder.cs
@@ -33,20 +33,14 @@ namespace WebApp.Utils
     {
         public static IConfidentialClientApplication BuildConfidentialClientApplication()
         {
-            return BuildConfidentialClientApplication(ClaimsPrincipal.Current);
-        }
-
-        public static IConfidentialClientApplication BuildConfidentialClientApplication(ClaimsPrincipal currentUser)
-        {
             IConfidentialClientApplication clientapp = ConfidentialClientApplicationBuilder.Create(AuthenticationConfig.ClientId)
                   .WithClientSecret(AuthenticationConfig.ClientSecret)
                   .WithRedirectUri(AuthenticationConfig.RedirectUri)
                   .WithAuthority(new Uri(AuthenticationConfig.Authority))
                   .Build();
 
-            // After the ConfidentialClientApplication is created, we overwrite its default UserTokenCache with our implementation
-            MSALPerUserMemoryTokenCache userTokenCache = new MSALPerUserMemoryTokenCache(clientapp.UserTokenCache, currentUser ?? ClaimsPrincipal.Current);
-
+            // After the ConfidentialClientApplication is created, we overwrite its default UserTokenCache serialization with our implementation
+            MSALPerUserMemoryTokenCache userTokenCache = new MSALPerUserMemoryTokenCache(clientapp.UserTokenCache);
             return clientapp;
         }
 
@@ -63,7 +57,6 @@ namespace WebApp.Utils
             var userAccount = await clientapp.GetAccountAsync(ClaimsPrincipal.Current.GetMsalAccountId());
 
             await clientapp.RemoveAsync(userAccount);
-            userTokenCache.Clear();
         }
     }
 }

--- a/WebApp/Web.config
+++ b/WebApp/Web.config
@@ -9,8 +9,8 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="ida:ClientId" value="e7f4bee0-c344-4a21-9a4b-0abed67d8aca" />
-    <add key="ida:ClientSecret" value="BjftonLFuN5Di0JwQvDn3aR1wAnx3k/M6n2oS4FNc4c=" />
+    <add key="ida:ClientId" value="[Enter your client ID, as obtained from the app registration portal]" />
+    <add key="ida:ClientSecret" value="[Enter your client secret, as obtained from the app registration portal]" />
     <add key="ida:AADInstance" value="https://login.microsoftonline.com/{0}{1}" />
     <add key="ida:RedirectUri" value="https://localhost:44326/" />
     <add key="vs:EnableBrowserLink" value="false" />

--- a/WebApp/Web.config
+++ b/WebApp/Web.config
@@ -9,8 +9,8 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="ida:ClientId" value="[Enter your client ID, as obtained from the app registration portal]" />
-    <add key="ida:ClientSecret" value="[Enter your client secret, as obtained from the app registration portal]" />
+    <add key="ida:ClientId" value="e7f4bee0-c344-4a21-9a4b-0abed67d8aca" />
+    <add key="ida:ClientSecret" value="BjftonLFuN5Di0JwQvDn3aR1wAnx3k/M6n2oS4FNc4c=" />
     <add key="ida:AADInstance" value="https://login.microsoftonline.com/{0}{1}" />
     <add key="ida:RedirectUri" value="https://localhost:44326/" />
     <add key="vs:EnableBrowserLink" value="false" />

--- a/WebApp/packages.config
+++ b/WebApp/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.4" targetFramework="net472" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.4" targetFramework="net472" />
-  <package id="Microsoft.Identity.Client" version="4.7.1" targetFramework="net472" />
+  <package id="Microsoft.Identity.Client" version="4.16.0" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.4.0" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.Logging" version="5.4.0" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.Protocols" version="5.4.0" targetFramework="net472" />


### PR DESCRIPTION
Updating to MSAL.NET 4.16
- using the `SuggestedCacheKey` of `TokenCacheNotificationArgs ` as the cache key
- using the `HasTokens` of `TokenCacheNotificationArgs ` to remove the record corresponding to the user when there are no longer any token in the cache for the user (after signout)