### PR TITLE
update id web 1.6.0

### DIFF
--- a/WebApp/Controllers/HomeController.cs
+++ b/WebApp/Controllers/HomeController.cs
@@ -46,14 +46,13 @@ namespace WebApp.Controllers
         {
             // Before we render the send email screen, we use the incremental consent to obtain and cache the access token with the correct scopes
             IConfidentialClientApplication app = await MsalAppBuilder.BuildConfidentialClientApplication();
-            AuthenticationResult result = null;
             var account = await app.GetAccountAsync(ClaimsPrincipal.Current.GetAccountId());
             string[] scopes = { "Mail.Send" };
 
             try
             {
 				// try to get an already cached token
-				result = await app.AcquireTokenSilent(scopes, account).ExecuteAsync().ConfigureAwait(false);
+				await app.AcquireTokenSilent(scopes, account).ExecuteAsync().ConfigureAwait(false);
             }
             catch (MsalUiRequiredException ex)
             {
@@ -64,7 +63,7 @@ namespace WebApp.Controllers
                 try
                 {
                     // Build the auth code request Uri
-                    string authReqUrl = await OAuth2RequestManager.GenerateAuthorizationRequestUrl(scopes, app, this.HttpContext, Url);
+                    string authReqUrl = await OAuth2RequestManager.GenerateAuthorizationRequestUrl(scopes, app, HttpContext, Url);
                     ViewBag.AuthorizationRequest = authReqUrl;
                     ViewBag.Relogin = "true";
                 }
@@ -104,14 +103,13 @@ namespace WebApp.Controllers
   ""SaveToSentItems"": ""false""
 }}
 ";
-            string message = String.Format(messagetemplate, subject, body, recipient);
+            string message = string.Format(messagetemplate, subject, body, recipient);
 
             HttpClient client = new HttpClient();
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/sendMail")
             {
                 Content = new StringContent(message, Encoding.UTF8, "application/json")
             };
-
 
             IConfidentialClientApplication app = await MsalAppBuilder.BuildConfidentialClientApplication();
             AuthenticationResult result = null;

--- a/WebApp/MailApp.csproj
+++ b/WebApp/MailApp.csproj
@@ -158,7 +158,7 @@
       <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Web">
-      <Version>1.5.1</Version>
+      <Version>1.6.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
       <Version>5.4.0</Version>


### PR DESCRIPTION
- not sure why, but this `await app.GetAccountAsync(ClaimsPrincipal.Current.GetAccountId());` always returns null. @jmprieur since you tested last time, maybe you got it to work? if not, i'll investigate. we also have an open issue for this as well. 