### PR TITLE
Fixing #48

### DIFF
--- a/WebApp/Utils/MsalAppBuilder.cs
+++ b/WebApp/Utils/MsalAppBuilder.cs
@@ -75,15 +75,19 @@ namespace WebApp.Utils
         }
 
 
+        private static IServiceProvider serviceProvider;
+
         private static IMsalTokenCacheProvider CreateTokenCacheSerializer()
         {
-            IServiceCollection services = new ServiceCollection();
+            if (serviceProvider == null)
+            {
+                // In memory token cache. Other forms of serialization are possible.
+                // See https://github.com/AzureAD/microsoft-identity-web/wiki/asp-net 
+                IServiceCollection services = new ServiceCollection();
+                services.AddInMemoryTokenCaches();
 
-            // In memory token cache. Other forms of serialization are possible.
-            // See https://github.com/AzureAD/microsoft-identity-web/wiki/asp-net 
-            services.AddInMemoryTokenCaches();
-
-            IServiceProvider serviceProvider = services.BuildServiceProvider();
+                serviceProvider = services.BuildServiceProvider();
+            }
             IMsalTokenCacheProvider msalTokenCacheProvider = serviceProvider.GetRequiredService<IMsalTokenCacheProvider>();
             return msalTokenCacheProvider;
         }


### PR DESCRIPTION
Fixes the problem `await app.GetAccountAsync(ClaimsPrincipal.Current.GetAccountId());` always returns null,

What happened?
The service provider was re-created each time we called BuildConfidentialClientApplication(), and therefore there were as many InMemoryCache as apps created, whereas the InMemoryCache should be one service for the application

This PR makes sure the service provider is a singleton.
I also updated https://github.com/AzureAD/microsoft-identity-web/wiki/asp-net